### PR TITLE
template_file is deprecated

### DIFF
--- a/deploy/versions.tf
+++ b/deploy/versions.tf
@@ -5,11 +5,11 @@ terraform {
   required_providers {
     aws = {
       source = "hashicorp/aws"
-      version = "3.66.0"
+      version = ">=3.63"
     }
     awscc = {
       source = "hashicorp/awscc"
-      version = "0.8.0"
+      version = "0.46.0"
     }
   }
 }


### PR DESCRIPTION
This change would fix the error I noticed when executing terraform init---basically the provider is now deprecated: registry.terraform.io/hashicorp/template
```
terraform init
Initializing modules...
- account in modules/account
- acm in modules/acm
- base in modules/base
- magento in modules/magento
- magento-ami in modules/magento-ami
- services in modules/services
- ssm in modules/ssm
- varnish-ami in modules/varnish-ami

Initializing the backend...

Initializing provider plugins...
- Finding latest version of hashicorp/aws...
- Finding latest version of hashicorp/awscc...
- Finding latest version of hashicorp/template...
- Finding latest version of hashicorp/random...
- Installing hashicorp/random v3.4.3...
- Installed hashicorp/random v3.4.3 (signed by HashiCorp)
- Installing hashicorp/aws v4.55.0...
- Installed hashicorp/aws v4.55.0 (signed by HashiCorp)
- Installing hashicorp/awscc v0.46.0...
- Installed hashicorp/awscc v0.46.0 (signed by HashiCorp)
╷
│ Error: Incompatible provider version
│ 
│ Provider registry.terraform.io/hashicorp/template v2.2.0 does not have a package available for your
│ current platform, darwin_arm64.
```
│ 
│ Provider releases are separate from Terraform CLI releases, so not all providers are available for all
│ platforms. Other versions of this provider may have different platforms supported.